### PR TITLE
[DOCS] local 개발 환경 설정 파일 gitignore에 추가 및 README.md에 로컬 환경 설정 설명 추가 #9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,5 @@ id_ed25519
 
 ###############################################
 .idea/
+src/main/resources/application-local.yaml
+

--- a/README.md
+++ b/README.md
@@ -179,7 +179,29 @@ docs: 협업 규칙 추가
 
 ---
 
-## 9. 도커 개발 환경 실행
+## 11. 로컬 개발 환경 설정
+
+로컬 MySQL 환경에서 Spring Boot를 실행하려면 아래 설정 파일을 직접 생성해야 합니다.
+이 파일은 Git에 포함되지 않으며, 각자 로컬 환경에 맞게 설정합니다.
+
+- 파일 생성 경로
+```
+src/main/resources/application-local.yaml
+```
+
+- 설정 파일 기본 형식 (application-local.yaml)
+```
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/{본인_DB_이름}
+    username: {본인_DB_아이디}
+    password: {본인_DB_비밀번호}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+```
+
+---
+
+## 10. 도커 개발 환경 실행
 
 - 컨테이너 실행
 ```
@@ -195,7 +217,7 @@ docker-compose down
 
 ---
 
-## 10. 참고 자료
+## 11. 참고 자료
 
 - [마크다운(markdown) 작성법](https://gist.github.com/ihoneymon/652be052a0727ad59601)
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#9 
## 📝작업 내용

application-local.yaml은 각자 로컬 개발 환경에 맞추기 때문에 gitignore에 추가했고,
파일 루트와 형식 설명을 README.md에 추가했습니다.
