### PR TITLE
[FEAT]worker attendance로직 추가

### DIFF
--- a/src/main/java/com/example/the_labot_backend/attendance/AttendanceController.java
+++ b/src/main/java/com/example/the_labot_backend/attendance/AttendanceController.java
@@ -1,0 +1,79 @@
+package com.example.the_labot_backend.attendance;
+
+import com.example.the_labot_backend.attendance.dto.ClockInOutRequestDto;
+import com.example.the_labot_backend.attendance.dto.ObjectionRequestDto;
+import com.example.the_labot_backend.users.User;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import com.example.the_labot_backend.attendance.dto.ClockInOutResponseDto;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/worker/attendance") // [★] 근로자(worker)용 API
+@RequiredArgsConstructor
+public class AttendanceController {
+    private final AttendanceService attendanceService;
+
+    /**
+     * [★ 신규 ★]
+     * 근로자가 출근 또는 퇴근 버튼을 눌렀을 때 호출
+     * (GPS 좌표를 받아 서버에서 검증)
+     */
+    @PostMapping("/clock-in-out")
+    public ResponseEntity<?> clockInOut(
+            // [★] 현재 로그인한 유저 정보를 자동으로 가져옴
+            @AuthenticationPrincipal User user,
+            @RequestBody ClockInOutRequestDto dto) { // [★] 현재 GPS 좌표
+
+        try {
+            ClockInOutResponseDto resultDto = attendanceService.recordClockInOut(user, dto);
+
+            // 출근인지 퇴근인지 확인
+            String message = (resultDto.getClockOutTime() == null) ? "출근 처리 완료" : "퇴근 처리 완료";
+
+            return ResponseEntity.ok(Map.of(
+                    "status", 200,
+                    "message", message,
+                    "data", resultDto
+            ));
+
+        } catch (IllegalStateException e) {
+            // (예: "현장과 너무 멉니다", "이미 퇴근했습니다" 등)
+            return ResponseEntity.status(400).body(Map.of(
+                    "status", 400,
+                    "message", e.getMessage()
+            ));
+        }
+    }
+    // ▼▼▼▼▼ [★ 2. 이 메서드 블록 전체를 추가 ★] ▼▼▼▼▼
+    /**
+     * [신규] 근로자가 특정 출퇴근 기록에 "이의제기" 제출
+     *
+     * @param attendanceId 수정할 출퇴근 기록의 고유 ID (PK)
+     * @param dto (예: { "message": "퇴근 버튼을 못 눌렀습니다" })
+     */
+    @PatchMapping("/{attendanceId}/object") // (PATCH /api/worker/attendance/101/object)
+    public ResponseEntity<?> submitObjection(
+            @AuthenticationPrincipal User user, // 현재 로그인한 근로자
+            @PathVariable Long attendanceId,
+            @RequestBody ObjectionRequestDto dto) {
+
+        try {
+            attendanceService.submitObjection(user, attendanceId, dto);
+            return ResponseEntity.ok(Map.of(
+                    "status", 200,
+                    "message", "이의제기가 성공적으로 제출되었습니다."
+            ));
+        } catch (IllegalStateException | EntityNotFoundException e) {
+            return ResponseEntity.status(400).body(Map.of(
+                    "status", 400,
+                    "message", e.getMessage()
+            ));
+        }
+    }
+    // ▲▲▲▲▲ [★ 2. 여기까지 추가 ★] ▲▲▲▲▲
+}

--- a/src/main/java/com/example/the_labot_backend/attendance/AttendanceRepository.java
+++ b/src/main/java/com/example/the_labot_backend/attendance/AttendanceRepository.java
@@ -1,6 +1,11 @@
 package com.example.the_labot_backend.attendance;
 
+import com.example.the_labot_backend.workers.Worker;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+    Optional<Attendance> findByWorkerAndDate(Worker worker, LocalDate date);
 }

--- a/src/main/java/com/example/the_labot_backend/attendance/AttendanceService.java
+++ b/src/main/java/com/example/the_labot_backend/attendance/AttendanceService.java
@@ -1,0 +1,138 @@
+package com.example.the_labot_backend.attendance;
+
+import com.example.the_labot_backend.attendance.dto.ClockInOutRequestDto;
+import com.example.the_labot_backend.attendance.dto.ObjectionRequestDto;
+import com.example.the_labot_backend.sites.Site;
+import com.example.the_labot_backend.users.User;
+import com.example.the_labot_backend.users.UserRepository;  //임시임
+import com.example.the_labot_backend.workers.Worker;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.example.the_labot_backend.attendance.dto.ClockInOutResponseDto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceService {
+    private final AttendanceRepository attendanceRepository;
+
+
+    // ▼▼▼ [★ 1. 기준 시간 2개 설정] ▼▼▼
+    private static final LocalTime NINE_AM = LocalTime.of(9, 0);  // 9시 00분 00초
+    private static final LocalTime TEN_AM = LocalTime.of(10, 0); // 10시 00분 00초
+
+
+    // 현장 허용 거리 (예: 100미터)
+    private static final double ALLOWED_DISTANCE_METERS = 100.0;
+
+    @Transactional
+    public ClockInOutResponseDto recordClockInOut(User user, ClockInOutRequestDto dto) {
+
+
+        Worker worker = user.getWorker();
+        if (worker == null) {
+            throw new IllegalStateException("근로자 정보가 없는 유저입니다.");
+        }
+
+        Site site = user.getSite();
+        if (site == null || site.getLatitude() == null || site.getLongitude() == null) {
+            throw new IllegalStateException("배정된 현장이 없거나, 현장에 GPS 좌표가 등록되지 않았습니다.");
+        }
+
+        // --- 1. [핵심] GPS 위치 검증 ---
+        double distance = calculateDistance(
+                dto.getLatitude(), dto.getLongitude(), // [★] 사람 위치 (DTO)
+                site.getLatitude(), site.getLongitude() // [★] 현장 위치 (Site)
+        );
+
+        if (distance > ALLOWED_DISTANCE_METERS) {
+            throw new IllegalStateException("현장과 너무 멉니다. (거리: " + (int)distance + "m)");
+        }
+
+        // --- 2. 오늘 날짜의 출근 기록 찾기 ---
+        LocalDate today = LocalDate.now();
+        LocalTime now = LocalTime.now(); // [★] 버튼 누른 현재 시간
+
+        Optional<Attendance> existingRecord = attendanceRepository.findByWorkerAndDate(worker, today);
+
+        if (existingRecord.isEmpty()) {
+
+            // --- 3. [출근 처리] ---
+
+            // ▼▼▼ [★ 2. 10시/9시 기준 판별 로직 수정] ▼▼▼
+            AttendanceStatus status;
+            if (!now.isBefore(TEN_AM)) { // 10시 00분 00초 "이후" (>= 10:00)
+                status = AttendanceStatus.ABSENT; // 결근
+            } else if (!now.isBefore(NINE_AM)) { // 9시 00분 00초 "이후" (>= 9:00 and < 10:00)
+                status = AttendanceStatus.LATE; // 지각
+            } else { // 9시 "이전" (< 9:00)
+                status = AttendanceStatus.PRESENT; // 출근(정상)
+            }
+            // ▲▲▲ [★ 2. 10시/9시 기준 판별 로직 수정] ▲▲▲
+
+
+
+            Attendance newRecord = Attendance.builder()
+                    .worker(worker)
+                    .date(today)
+                    .clockInTime(now) // [★] 그냥 현재 시간 저장
+                    .status(status)
+                    .build();
+            Attendance savedRecord = attendanceRepository.save(newRecord);
+            return ClockInOutResponseDto.fromEntity(savedRecord);
+
+        } else {
+            // --- 4. [퇴근 처리] ---
+            Attendance record = existingRecord.get();
+            if (record.getClockOutTime() != null) {
+                throw new IllegalStateException("이미 퇴근 처리가 완료되었습니다.");
+            }
+            record.setClockOutTime(now); // [★] 그냥 현재 시간 저장
+            Attendance savedRecord = attendanceRepository.save(record);
+            return ClockInOutResponseDto.fromEntity(savedRecord);
+        }
+    }
+    // ▼▼▼▼▼ [★ 2. 이 메서드 전체를 추가 ★] ▼▼▼▼▼
+    /**
+     * [신규] 근로자가 특정 출퇴근 기록에 대해 "이의제기"를 제출
+     */
+    @Transactional
+    public void submitObjection(User user, Long attendanceId, ObjectionRequestDto dto) {
+
+
+        // 1. 수정할 출퇴근 기록을 찾음
+        Attendance record = attendanceRepository.findById(attendanceId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 출퇴근 기록을 찾을 수 없습니다. ID: " + attendanceId));
+
+        // 2. [★보안★] 이 기록이 "현재 로그인한 근로자"의 기록이 맞는지 확인
+        if (!record.getWorker().getUser().getId().equals(user.getId())) {
+            throw new IllegalStateException("본인의 출퇴근 기록에만 이의제기를 할 수 있습니다.");
+        }
+
+        // 3. [★핵심★] "이의제기 메시지 보관함"에 메시지를 저장
+        record.setObjectionMessage(dto.getMessage());
+
+        // 4. DB에 저장
+        attendanceRepository.save(record);
+    }
+    // ▲▲▲▲▲ [★ 2. 여기까지 추가 ★] ▲▲▲▲▲
+
+    /**
+     * [신규 헬퍼] 두 GPS 좌표 간의 거리를 미터(m) 단위로 계산 (Haversine 공식)
+     */
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        final int R = 6371; // 지구 반지름 (km)
+        double latDistance = Math.toRadians(lat2 - lat1);
+        double lonDistance = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(lonDistance / 2) * Math.sin(lonDistance / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c * 1000; // m를 km로 변환
+    }
+}

--- a/src/main/java/com/example/the_labot_backend/attendance/AttendanceStatus.java
+++ b/src/main/java/com/example/the_labot_backend/attendance/AttendanceStatus.java
@@ -1,5 +1,6 @@
 package com.example.the_labot_backend.attendance;
 
+
 public enum AttendanceStatus {
     PRESENT, //정상
     LATE, //지각

--- a/src/main/java/com/example/the_labot_backend/attendance/dto/ClockInOutRequestDto.java
+++ b/src/main/java/com/example/the_labot_backend/attendance/dto/ClockInOutRequestDto.java
@@ -1,0 +1,9 @@
+package com.example.the_labot_backend.attendance.dto;
+
+import lombok.Data;
+
+@Data
+public class ClockInOutRequestDto {
+    private Double latitude;  // (앱에서 측정한 현재 위도)
+    private Double longitude; // (앱에서 측정한 현재 경도)
+}

--- a/src/main/java/com/example/the_labot_backend/attendance/dto/ClockInOutResponseDto.java
+++ b/src/main/java/com/example/the_labot_backend/attendance/dto/ClockInOutResponseDto.java
@@ -1,0 +1,29 @@
+package com.example.the_labot_backend.attendance.dto;
+
+import com.example.the_labot_backend.attendance.Attendance;
+import com.example.the_labot_backend.attendance.AttendanceStatus;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+@Data
+@Builder
+public class ClockInOutResponseDto {
+    private Long attendanceId;  // 방금 생성/수정된 기록의 ID
+    private LocalDate date;       // 날짜
+    private LocalTime clockInTime;  // 출근 시간
+    private LocalTime clockOutTime; // 퇴근 시간
+    private AttendanceStatus status;   // 상태 (null일 수 있음)
+
+    // [★] 엔티티를 DTO로 변환해주는 헬퍼 메서드
+    public static ClockInOutResponseDto fromEntity(Attendance entity) {
+        return ClockInOutResponseDto.builder()
+                .attendanceId(entity.getId())
+                .date(entity.getDate())
+                .clockInTime(entity.getClockInTime())
+                .clockOutTime(entity.getClockOutTime())
+                .status(entity.getStatus())
+                .build();
+    }
+}

--- a/src/main/java/com/example/the_labot_backend/attendance/dto/ObjectionRequestDto.java
+++ b/src/main/java/com/example/the_labot_backend/attendance/dto/ObjectionRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.the_labot_backend.attendance.dto;
+
+import lombok.Data;
+
+@Data
+public class ObjectionRequestDto {
+    private String message;
+}

--- a/src/main/java/com/example/the_labot_backend/sites/Site.java
+++ b/src/main/java/com/example/the_labot_backend/sites/Site.java
@@ -35,4 +35,12 @@ public class Site {
     private String constructionType; // 공사규모/타입 (예: 대형주택, 도로공사, 아파트 등)
     private String client;           // 발주처
     private String contractor;       // 시공사
+
+    // gps이용을 위해서 추가함. 11/17 박찬홍
+    @Column(nullable = false) // (출퇴근 기능이 필수라면 false로 설정)
+    private Double latitude; // 현장 위도 (기준점)
+
+    @Column(nullable = false)
+    private Double longitude; // 현장 경도 (기준점)
+    //
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#44 
> ex) #이슈번호, #이슈번호
## 📝작업 내용
근로자가  gps를 통해서 출퇴근 등록을 가능하게끔함, 근로자가 이의제기를 보낼 수 있게끔함.

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 스크린샷 (선택)
site엔티티에 경도와 위도 필드를 추가함.
이의제기,리퀘스트, 리스펀스에 관한 dto를 만듬
근로자가 출퇴근 버튼을 누르는 시간을 서버가 전달 받아서 시간에 따른 정상, 지각, 결석으로 구분짓게함
거리가 100m이상인 경우 거리가 너무 멀기때문에 출퇴근 등록을 못한다고함
attendance 엔티티에 이의제기 항목이 있기때문에 근로자가 이의제기를 신청할때는 patch를 이용했음

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
