### PR TITLE
[FEAT] 깃허브 액션 CD 캐싱 추가 및 README.md 저장소 제목 붙임 #78

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # 캐싱
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -25,6 +29,9 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: rmsckd1640/the-labot-backend:latest
+
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   deploy:
     needs: build-and-push

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# the-labot-frontend
+
 ## 로컬 개발 환경 설정
 
 로컬 MySQL 환경에서 Spring Boot를 실행하려면 아래 설정 파일을 직접 생성해야 합니다.


### PR DESCRIPTION
## #️⃣연관된 이슈

#78 
## 📝작업 내용

- GitHub Actions CD 파이프라인에 Docker Buildx 캐싱을 적용하여 빌드 속도 개선
- README.md 상단 제목 저장소 이름 붙임