### PR TITLE
[FIX] 본사관리자의 현장 근로자 확인 기능 추가, 근로자 상세볼때 현장명 site의 projectName가지고 오게끔 #98

### DIFF
--- a/src/main/java/com/example/the_labot_backend/admins/controller/AdminWorkerController.java
+++ b/src/main/java/com/example/the_labot_backend/admins/controller/AdminWorkerController.java
@@ -1,0 +1,48 @@
+package com.example.the_labot_backend.admins.controller;
+
+import com.example.the_labot_backend.admins.dto.AdminWorkerListResponse;
+import com.example.the_labot_backend.admins.service.AdminWorkerService;
+import com.example.the_labot_backend.authuser.entity.User;
+import com.example.the_labot_backend.authuser.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/admin/workers") // 본사 관리자용 경로
+@RequiredArgsConstructor
+public class AdminWorkerController {
+
+    private final AdminWorkerService adminWorkerService;
+    private final UserRepository userRepository;
+
+    // 통합 근로자 목록 조회 (GET)
+    @GetMapping
+    public ResponseEntity<?> getAllWorkers() {
+
+        // 1. 현재 로그인한 관리자 ID 추출
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Long adminId = Long.parseLong(auth.getName());
+
+        // 2. 관리자 정보 조회
+        User admin = userRepository.findById(adminId)
+                .orElseThrow(() -> new RuntimeException("관리자 정보를 찾을 수 없습니다."));
+
+        // 3. 서비스 호출 (본사 산하 모든 근로자 가져오기)
+        List<AdminWorkerListResponse> workerList = adminWorkerService.getAllWorkersByHeadOffice(admin);
+
+        return ResponseEntity.ok(Map.of(
+                "status", 200,
+                "message", "본사 통합 근로자 목록 조회 성공",
+                "count", workerList.size(),
+                "data", workerList
+        ));
+    }
+}

--- a/src/main/java/com/example/the_labot_backend/admins/dto/AdminWorkerListResponse.java
+++ b/src/main/java/com/example/the_labot_backend/admins/dto/AdminWorkerListResponse.java
@@ -1,0 +1,43 @@
+package com.example.the_labot_backend.admins.dto;
+
+import com.example.the_labot_backend.workers.entity.Worker;
+import com.example.the_labot_backend.workers.entity.WorkerStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class AdminWorkerListResponse {
+    private Long workerId;          // 근로자 ID
+    private String name;            // 근로자 이름
+    private String siteName;        // [★] 소속 현장명
+    private String position;        // 직종
+    private WorkerStatus status;    // 상태 (근무중/퇴직 등)
+    private String phone;           // 전화번호
+
+    // 표에 보여줄 상세 정보들
+    private String contractType;    // 계약 형태
+    private LocalDate wageStartDate;// 근무 시작일
+    private LocalDate wageEndDate;  // 근무 종료일
+    private String salary;          // 급여
+
+    public static AdminWorkerListResponse from(Worker worker) {
+        return AdminWorkerListResponse.builder()
+                .workerId(worker.getId())
+                .name(worker.getUser().getName())
+
+
+                .siteName(worker.getUser().getSite().getProjectName()) //site에서 projectName가지고옴
+                //.siteName(worker.getSiteName()) 아직 worker엔티티에 현장명이 존재하긴함.
+                .position(worker.getPosition())
+                .status(worker.getStatus())
+                .phone(worker.getUser().getPhoneNumber())
+                .contractType(worker.getContractType())
+                .wageStartDate(worker.getWageStartDate())
+                .wageEndDate(worker.getWageEndDate())
+                .salary(worker.getSalary())
+                .build();
+    }
+}

--- a/src/main/java/com/example/the_labot_backend/admins/service/AdminWorkerService.java
+++ b/src/main/java/com/example/the_labot_backend/admins/service/AdminWorkerService.java
@@ -1,0 +1,40 @@
+package com.example.the_labot_backend.admins.service;
+
+
+import org.springframework.transaction.annotation.Transactional;
+import com.example.the_labot_backend.admins.dto.AdminWorkerListResponse;
+import com.example.the_labot_backend.authuser.entity.User;
+import com.example.the_labot_backend.workers.entity.Worker;
+import com.example.the_labot_backend.workers.repository.WorkerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminWorkerService {
+    private final WorkerRepository workerRepository;
+
+    /**
+     * 본사 관리자(adminUser)가 속한 본사의 모든 현장 근로자 조회
+     */
+    public List<AdminWorkerListResponse> getAllWorkersByHeadOffice(User adminUser) {
+        // 1. 관리자의 본사 정보 확인
+        if (adminUser.getHeadOffice() == null) {
+            throw new RuntimeException("해당 관리자는 본사 소속이 아닙니다.");
+        }
+
+        Long headOfficeId = adminUser.getHeadOffice().getId();
+
+        // 2. 해당 본사 ID로 모든 근로자 조회 (Repository 호출)
+        List<Worker> workers = workerRepository.findAllByHeadOfficeId(headOfficeId);
+
+        // 3. DTO 변환
+        return workers.stream()
+                .map(AdminWorkerListResponse::from)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/example/the_labot_backend/hazards/service/HazardService.java
+++ b/src/main/java/com/example/the_labot_backend/hazards/service/HazardService.java
@@ -100,6 +100,7 @@ public class HazardService {
                 .orElseThrow(() -> new NoSuchElementException("해당 위험요소 신고를 찾을 수 없습니다.(updateStatus) hazardId:" + hazardId));
 
         hazard = Hazard.builder()
+                .site(hazard.getSite()) //site가 null이 되는거 해결!
                 .id(hazard.getId())
                 .hazardType(hazard.getHazardType())
                 .location(hazard.getLocation())

--- a/src/main/java/com/example/the_labot_backend/workers/dto/WorkerDetailResponse.java
+++ b/src/main/java/com/example/the_labot_backend/workers/dto/WorkerDetailResponse.java
@@ -23,7 +23,7 @@ public class WorkerDetailResponse {
     private String gender;
     private String nationality;
     private String position;
-    private Site site;
+    private String siteProjectName;
 
     private WorkerStatus status; // 근무중, 대기중 등
 

--- a/src/main/java/com/example/the_labot_backend/workers/repository/WorkerRepository.java
+++ b/src/main/java/com/example/the_labot_backend/workers/repository/WorkerRepository.java
@@ -3,9 +3,17 @@ package com.example.the_labot_backend.workers.repository;
 import com.example.the_labot_backend.workers.entity.Worker;
 import com.example.the_labot_backend.workers.entity.WorkerStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface WorkerRepository extends JpaRepository<Worker, Long> {
     List<Worker> findAllByStatus(WorkerStatus status);
+
+    @Query("SELECT w FROM Worker w " +
+            "JOIN FETCH w.user u " +
+            "JOIN FETCH u.site s " +
+            "WHERE u.headOffice.id = :headOfficeId")
+    List<Worker> findAllByHeadOfficeId(@Param("headOfficeId") Long headOfficeId);
 }

--- a/src/main/java/com/example/the_labot_backend/workers/service/WorkerService.java
+++ b/src/main/java/com/example/the_labot_backend/workers/service/WorkerService.java
@@ -8,6 +8,7 @@ import com.example.the_labot_backend.authuser.entity.User;
 import com.example.the_labot_backend.authuser.repository.UserRepository;
 import com.example.the_labot_backend.files.dto.FileResponse;
 import com.example.the_labot_backend.files.service.FileService;
+import com.example.the_labot_backend.headoffice.entity.HeadOffice;
 import com.example.the_labot_backend.ocr.dto.FinalSaveDto;
 import com.example.the_labot_backend.sites.entity.Site;
 
@@ -46,6 +47,7 @@ public class WorkerService {
                 .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다.(getReportsByUser) userId:" + managerId));
 
         Site site = manager.getSite();
+        HeadOffice headOffice = site.getHeadOffice();
 
         if (manager.getRole() != Role.ROLE_MANAGER) {
             throw new RuntimeException("현장관리자만 근로자를 등록할 수 있습니다.");
@@ -66,6 +68,7 @@ public class WorkerService {
                 .name(request.getName())
                 .role(Role.ROLE_WORKER)
                 .site(site)
+                .headOffice(headOffice) // [★ 추가] 본사 정보 직접 주입!
                 .build();
 
         userRepository.save(workerUser);
@@ -198,7 +201,7 @@ public class WorkerService {
                 .gender(worker.getGender())
                 .nationality(worker.getNationality())
                 .position(worker.getPosition())
-                .site(worker.getUser().getSite())
+                .siteProjectName(worker.getUser().getSite().getProjectName())//siteName만을 전달함
                 // --- [추가 1] 상태/프로필 ---
                 .status(worker.getStatus())
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#98 
> ex) #이슈번호, #이슈번호
## 📝작업 내용
본사관리자의 현장 확인 기능
본사관리자가 근로자 상세 확인할때 site의 projectName으로 가지고옴

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
