### PR TITLE
[FIX] 민감정보 로그 노출 제거 및 System.out.println 정리 #154

### DIFF
--- a/src/main/java/com/example/the_labot_backend/authuser/service/AuthService.java
+++ b/src/main/java/com/example/the_labot_backend/authuser/service/AuthService.java
@@ -36,12 +36,8 @@ public class AuthService {
         User user = userRepository.findByPhoneNumber(request.getPhoneNumber())
                 .orElseThrow(() -> new BadCredentialsException("해당 전화번호가 존재하지 않습니다."));
 
-        // **테스트용 임시 주석 처리
         // 비밀번호 조회
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-
-            System.out.println("암호화된 비밀번호: " + passwordEncoder.encode(request.getPassword()));
-            System.out.println("암호화된 비밀번호: " + user.getPassword());
             throw new BadCredentialsException("비밀번호가 올바르지 않습니다.");
         }
 

--- a/src/main/java/com/example/the_labot_backend/authuser/service/UserService.java
+++ b/src/main/java/com/example/the_labot_backend/authuser/service/UserService.java
@@ -31,22 +31,14 @@ public class UserService {
         }
 
         // 임시 비밀번호 생성
-        String tempPassword = "1234";
-    //    String tempPassword = generateTempPassword();
+        String tempPassword = generateTempPassword();
 
-        // 비밀번호 변경
+        // 비밀번호 변경 (암호화 후 저장)
         user.setPassword(passwordEncoder.encode(tempPassword));
-
-        // 암호화 후 저장
-        String encoded = passwordEncoder.encode(tempPassword);
-        user.setPassword(encoded);
 
         // UPDATE 반영 (필수!! — 이게 빠지면 저장 X)
         userRepository.save(user);
 
-        System.out.println(tempPassword);
-
-        // 테스트용 임시 SMS 전송 주석
         // SMS 전송
         smsService.sendSms(
                 phoneNumber,

--- a/src/main/java/com/example/the_labot_backend/global/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/the_labot_backend/global/config/JwtAuthenticationFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -19,6 +20,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.List;
 
+@Slf4j
 @Component
 //OncePerRequestFilter는 요청마다 딱 한번 실행되는 필터
 //요청이 1회 들어올 때 마다 doFilterInternal()이 호출됨.
@@ -42,8 +44,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
             throws ServletException, IOException {
 
-        // 디버깅 용
-        System.out.println("JwtFilter 실행됨: " + request.getRequestURI() + "\n");
+        log.debug("JwtFilter 실행: {}", request.getRequestURI());
 
         // 1) 인증 필요 없는 경로는 필터 통과
         String path = request.getRequestURI();
@@ -70,7 +71,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String id = jwtTokenProvider.getIdFromToken(token);
             String role = jwtTokenProvider.getRoleFromToken(token);
 
-            System.out.println(role);
+            log.debug("인증 완료. userId={}, role={}", id, role);
 
             UserDetails userDetails = userDetailsService.loadUserByUsername(id);
 

--- a/src/main/java/com/example/the_labot_backend/ocr/controller/OcrController.java
+++ b/src/main/java/com/example/the_labot_backend/ocr/controller/OcrController.java
@@ -7,6 +7,7 @@ import com.example.the_labot_backend.ocr.service.ContractOcrService;
 import com.example.the_labot_backend.ocr.service.IdCardOcrService;
 import com.example.the_labot_backend.ocr.service.RegistrationService;
 import com.example.the_labot_backend.workers.entity.Worker;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/manager/register")
 public class OcrController {
@@ -39,7 +41,7 @@ public class OcrController {
             return ResponseEntity.ok(extractedData);
 
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("근로계약서 OCR 처리 실패", e);
             // 실제로는 @ControllerAdvice 등으로 더 정교한 에러 처리가 필요
             return ResponseEntity.status(500).body(null);
         }
@@ -57,7 +59,7 @@ public class OcrController {
             return ResponseEntity.ok(extractedData);
 
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("신분증 OCR 처리 실패", e);
             return ResponseEntity.status(500).body(null);
         }
     }
@@ -75,7 +77,7 @@ public class OcrController {
             return ResponseEntity.ok("근로자 등록이 (메모리에) 완료되었습니다.");
 
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("근로자 등록 저장 실패", e);
             return ResponseEntity.status(500).body("저장 중 오류가 발생했습니다.");
         }
     }
@@ -91,7 +93,7 @@ public class OcrController {
             List<Worker> workers = registrationService.getAllWorkers();
             return ResponseEntity.ok(workers);
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("근로자 목록 조회 실패", e);
             return ResponseEntity.status(500).body(null);
         }
     }

--- a/src/main/java/com/example/the_labot_backend/ocr/service/ClovaOcrClient.java
+++ b/src/main/java/com/example/the_labot_backend/ocr/service/ClovaOcrClient.java
@@ -2,6 +2,7 @@ package com.example.the_labot_backend.ocr.service;
 
 import com.example.the_labot_backend.ocr.dto.ClovaOcrResponseDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.*;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+@Slf4j
 @Service
 public class ClovaOcrClient {
     private final RestTemplate restTemplate;
@@ -145,7 +147,7 @@ public class ClovaOcrClient {
             }
 
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("ID Card OCR 처리 실패", e);
             throw new RuntimeException("ID Card OCR 처리 중 예외 발생", e);
         }
     }

--- a/src/main/java/com/example/the_labot_backend/ocr/service/IdCardOcrService.java
+++ b/src/main/java/com/example/the_labot_backend/ocr/service/IdCardOcrService.java
@@ -24,7 +24,8 @@ public class IdCardOcrService {
     public IdCardDataDto processIdCard(MultipartFile imageFile) {
         try {
             String jsonResponse = clovaOcrClient.callIdCardApi(imageFile);
-            log.info("CLOVA ID CARD 원본 응답: {}", jsonResponse);
+            // 원본 응답에는 주민등록번호·주소 등 개인정보가 포함되므로 본문을 남기지 않는다
+            log.debug("CLOVA ID CARD 응답 수신 완료");
 
             // [★ 수정된 DTO]를 사용해서 JSON을 받음
             ClovaIdCardResponseDto clovaResponse = objectMapper.readValue(jsonResponse, ClovaIdCardResponseDto.class);
@@ -32,7 +33,7 @@ public class IdCardOcrService {
             return parseToIdCardData(clovaResponse);
 
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("ID Card OCR 파싱 실패", e);
             throw new RuntimeException("ID Card JSON 파싱 또는 처리 중 오류", e);
         }
     }
@@ -60,7 +61,7 @@ public class IdCardOcrService {
             throw new RuntimeException("인식된 신분증 정보(idCard.result)가 없습니다.");
         }
 
-        log.info("========= CLOVA '신분증' 파싱 시작 (필수 3종) =========");
+        log.debug("CLOVA 신분증 파싱 시작");
 
         IdCardDataDto dto = new IdCardDataDto();
         ClovaIdCardResponseDto.Result result = clovaResponse.getImages().get(0).getIdCard().getResult();
@@ -68,13 +69,13 @@ public class IdCardOcrService {
         // ★★★ 핵심 수정 ★★★
         ClovaIdCardResponseDto.IdData data;
         if (result.getDl() != null) {
-            log.info("운전면허증(dl) 데이터 감지");
+            log.debug("운전면허증(dl) 데이터 감지");
             data = result.getDl();
         } else if (result.getRc() != null) {
-            log.info("주민등록증(rc) 데이터 감지");
+            log.debug("주민등록증(rc) 데이터 감지");
             data = result.getRc();
         } else if (result.getIc() != null) { // ▼▼▼▼▼▼▼▼▼▼ [이 줄 추가!] ▼▼▼▼▼▼▼▼▼▼
-            log.info("주민등록증(ic) 데이터 감지");
+            log.debug("주민등록증(ic) 데이터 감지");
             data = result.getIc(); //             [이 줄 추가!]
         } else { // ▲▲▲▲▲▲▲▲▲▲ [이 줄 추가!] ▲▲▲▲▲▲▲▲▲▲
             throw new RuntimeException("dl, rc, ic 데이터를 모두 찾을 수 없습니다."); // (에러 메시지 수정)
@@ -85,7 +86,8 @@ public class IdCardOcrService {
         dto.setAddress(getFirstTextValue(data.getAddress()));
         dto.setResidentIdNumber(getFirstFormattedValue(data.getPersonalNum()));
 
-        log.info("========= CLOVA '신분증' 파싱 완료 (결과: {}) =========" , dto);
+        // dto에는 이름·주소·주민등록번호가 담기므로 값을 남기지 않는다
+        log.debug("CLOVA 신분증 파싱 완료");
         return dto;
     }
 

--- a/src/main/java/com/example/the_labot_backend/sites/service/SiteService.java
+++ b/src/main/java/com/example/the_labot_backend/sites/service/SiteService.java
@@ -203,8 +203,6 @@ public class SiteService {
         if (site == null) {
             throw new NotFoundException("해당 사용자에게 배정된 현장이 없습니다.");
         }
-        System.out.println(userId);
-        System.out.println(site.getProjectName());
         return SiteDetailResponse.from(site);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #154

## 📝작업 내용

운영 로그에 임시 비밀번호와 신분증 개인정보(주민등록번호)가 평문으로 기록되던 문제를 제거했습니다.
`System.out.println`과 `printStackTrace`는 로그 레벨로 제어할 수 없어 로거로 전환했습니다.

**비밀번호 관련**
- 임시 비밀번호 평문 출력 제거, 비밀번호 해시 출력 제거
- 로그 출력을 위해 BCrypt를 한 번 더 호출하던 부분 제거 (로그인 실패 경로)
- 하드코딩 `"1234"` → 이미 구현되어 있던 `generateTempPassword()`로 전환
- 같은 값을 두 번 인코딩하던 중복 제거

**신분증 개인정보**
- 파싱 결과 DTO 로깅 제거 — `IdCardDataDto`가 `@Data`라 `toString()`에 이름·주소·주민등록번호가 모두 포함됨
- CLOVA 원본 응답 전문 로깅 제거
- 파싱 흐름 로그를 `info` → `debug`로 조정

**System.out / printStackTrace**
- `printStackTrace` 6곳을 `log.error` + 맥락 메시지로 전환
- 매 요청 실행되는 `JwtAuthenticationFilter`의 `System.out`을 `log.debug`로 전환
- 디버깅용 출력 제거 (`SiteService`)

`TheLabotBackendApplication`의 출력 1건은 타임존 설정 블록에 포함되어 있어 #156에서 함께 제거됩니다.

## 💬리뷰 요구사항(선택)

하드코딩 제거로 SMS가 임시 비밀번호의 유일한 전달 경로가 되었습니다. solapi 키·잔액이 유효한지 확인이 필요합니다.
