### PR TITLE
[FIX] 예외 처리 정리 및 내부 정보 노출 차단 #155

### DIFF
--- a/src/main/java/com/example/the_labot_backend/admins/controller/AdminWorkerController.java
+++ b/src/main/java/com/example/the_labot_backend/admins/controller/AdminWorkerController.java
@@ -4,6 +4,7 @@ import com.example.the_labot_backend.admins.dto.AdminWorkerListResponse;
 import com.example.the_labot_backend.admins.service.AdminWorkerService;
 import com.example.the_labot_backend.authuser.entity.User;
 import com.example.the_labot_backend.authuser.repository.UserRepository;
+import com.example.the_labot_backend.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -34,7 +35,7 @@ public class AdminWorkerController {
 
         // 2. 관리자 정보 조회
         User admin = userRepository.findById(adminId)
-                .orElseThrow(() -> new RuntimeException("관리자 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("관리자 정보를 찾을 수 없습니다."));
 
         // 3. 서비스 호출 (본사 산하 모든 근로자 가져오기)
         List<AdminWorkerListResponse> workerList = adminWorkerService.getAllWorkersByHeadOffice(siteId,admin);

--- a/src/main/java/com/example/the_labot_backend/attendance/controller/AttendanceController.java
+++ b/src/main/java/com/example/the_labot_backend/attendance/controller/AttendanceController.java
@@ -5,6 +5,7 @@ import com.example.the_labot_backend.attendance.dto.ObjectionRequestDto;
 import com.example.the_labot_backend.attendance.service.AttendanceService;
 import com.example.the_labot_backend.authuser.entity.User;
 import com.example.the_labot_backend.authuser.repository.UserRepository;
+import com.example.the_labot_backend.global.exception.UnauthorizedException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -110,7 +111,7 @@ public class AttendanceController {
 
         // (혹시 모를 예외 처리)
         if (auth == null || auth.getName() == null) {
-            throw new RuntimeException("인증 정보가 없습니다.");
+            throw new UnauthorizedException("인증 정보가 없습니다.");
         }
 
         try {
@@ -118,7 +119,7 @@ public class AttendanceController {
             return userRepository.findById(userId)
                     .orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다. ID: " + userId));
         } catch (NumberFormatException e) {
-            throw new RuntimeException("유효하지 않은 토큰 ID 형식입니다.");
+            throw new UnauthorizedException("유효하지 않은 토큰 ID 형식입니다.");
         }
     }
 }

--- a/src/main/java/com/example/the_labot_backend/authuser/service/SmsService.java
+++ b/src/main/java/com/example/the_labot_backend/authuser/service/SmsService.java
@@ -1,6 +1,7 @@
 package com.example.the_labot_backend.authuser.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -12,6 +13,7 @@ import org.springframework.web.client.RestTemplate;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SmsService {
@@ -67,7 +69,8 @@ public class SmsService {
             // 5) 응답 검증
             // ─────────────────────────────────────────────
             if (!response.getStatusCode().is2xxSuccessful()) {
-                throw new RuntimeException("SMS 발송 실패: " + response.getBody());
+                log.error("SMS 발송 실패. status={}, response={}", response.getStatusCode(), response.getBody());
+                throw new RuntimeException("SMS 발송에 실패했습니다.");
             }
 
         } catch (Exception e) {

--- a/src/main/java/com/example/the_labot_backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/the_labot_backend/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.example.the_labot_backend.global.exception;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.security.SignatureException;
 
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -108,7 +110,9 @@ public class GlobalExceptionHandler {
     // ========================================================================
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception ex) {
-        return build(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", ex.getMessage());
+        // 예외 메시지에는 내부 클래스명·테이블명 등이 담길 수 있으므로 클라이언트에는 노출하지 않는다
+        log.error("Unhandled exception", ex);
+        return build(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다.");
     }
 
 

--- a/src/main/java/com/example/the_labot_backend/ocr/service/ContractOcrService.java
+++ b/src/main/java/com/example/the_labot_backend/ocr/service/ContractOcrService.java
@@ -1,5 +1,6 @@
 package com.example.the_labot_backend.ocr.service;
 
+import com.example.the_labot_backend.global.exception.BadRequestException;
 import com.example.the_labot_backend.ocr.dto.ClovaOcrResponseDto;
 import com.example.the_labot_backend.ocr.dto.ContractDataDto;
 import lombok.extern.slf4j.Slf4j;
@@ -35,7 +36,7 @@ public class ContractOcrService {
 
     private ContractDataDto parseToContractData(ClovaOcrResponseDto clovaResponse) {
         if (clovaResponse.getImages() == null || clovaResponse.getImages().isEmpty()) {
-            throw new RuntimeException("OCR 결과에 이미지가 없습니다.");
+            throw new BadRequestException("OCR 결과에 이미지가 없습니다.");
         }
 
 

--- a/src/main/java/com/example/the_labot_backend/ocr/service/IdCardOcrService.java
+++ b/src/main/java/com/example/the_labot_backend/ocr/service/IdCardOcrService.java
@@ -1,5 +1,6 @@
 package com.example.the_labot_backend.ocr.service;
 
+import com.example.the_labot_backend.global.exception.BadRequestException;
 import com.example.the_labot_backend.ocr.dto.ClovaIdCardResponseDto;
 import com.example.the_labot_backend.ocr.dto.IdCardDataDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -58,7 +59,7 @@ public class IdCardOcrService {
         if (clovaResponse.getImages() == null || clovaResponse.getImages().isEmpty() ||
                 clovaResponse.getImages().get(0).getIdCard() == null ||
                 clovaResponse.getImages().get(0).getIdCard().getResult() == null) {
-            throw new RuntimeException("인식된 신분증 정보(idCard.result)가 없습니다.");
+            throw new BadRequestException("인식된 신분증 정보(idCard.result)가 없습니다.");
         }
 
         log.debug("CLOVA 신분증 파싱 시작");
@@ -78,7 +79,7 @@ public class IdCardOcrService {
             log.debug("주민등록증(ic) 데이터 감지");
             data = result.getIc(); //             [이 줄 추가!]
         } else { // ▲▲▲▲▲▲▲▲▲▲ [이 줄 추가!] ▲▲▲▲▲▲▲▲▲▲
-            throw new RuntimeException("dl, rc, ic 데이터를 모두 찾을 수 없습니다."); // (에러 메시지 수정)
+            throw new BadRequestException("dl, rc, ic 데이터를 모두 찾을 수 없습니다."); // (에러 메시지 수정)
         }
 
         // --- 2. 필요한 3개 값만 매핑 ---

--- a/src/main/java/com/example/the_labot_backend/workers/controller/WorkerMyPageController.java
+++ b/src/main/java/com/example/the_labot_backend/workers/controller/WorkerMyPageController.java
@@ -3,6 +3,7 @@ package com.example.the_labot_backend.workers.controller;
 
 
 import com.example.the_labot_backend.files.dto.FileResponse;
+import com.example.the_labot_backend.global.exception.UnauthorizedException;
 import com.example.the_labot_backend.workers.dto.WorkerMyPageResponse;
 import com.example.the_labot_backend.workers.dto.WorkerMyPageUpdateRequest;
 import com.example.the_labot_backend.workers.service.WorkerMyPageService;
@@ -62,7 +63,7 @@ public class WorkerMyPageController {
     private Long getCurrentUserId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || auth.getName() == null) {
-            throw new RuntimeException("로그인 정보가 없습니다.");
+            throw new UnauthorizedException("로그인 정보가 없습니다.");
         }
         return Long.parseLong(auth.getName());
     }

--- a/src/main/java/com/example/the_labot_backend/workers/service/WorkerMyPageService.java
+++ b/src/main/java/com/example/the_labot_backend/workers/service/WorkerMyPageService.java
@@ -6,6 +6,7 @@ import com.example.the_labot_backend.files.dto.FileResponse;
 import com.example.the_labot_backend.files.entity.File;
 import com.example.the_labot_backend.files.repository.FileRepository;
 import com.example.the_labot_backend.files.service.FileService;
+import com.example.the_labot_backend.global.exception.NotFoundException;
 import com.example.the_labot_backend.workers.dto.WorkerMyPageResponse;
 import com.example.the_labot_backend.workers.dto.WorkerMyPageUpdateRequest;
 import com.example.the_labot_backend.workers.entity.Worker;
@@ -38,11 +39,11 @@ public class WorkerMyPageService {
     public WorkerMyPageResponse getMyPageInfo(Long userId) {
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("사용자 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("사용자 정보를 찾을 수 없습니다."));
 
         Worker worker = user.getWorker();
         if (worker == null) {
-            throw new RuntimeException("해당 계정은 근로자 정보가 등록되지 않았습니다.");
+            throw new NotFoundException("해당 계정은 근로자 정보가 등록되지 않았습니다.");
         }
 
         // [★ 수정됨] FileService를 통해 S3 URL이 포함된 DTO 리스트 조회
@@ -66,11 +67,11 @@ public class WorkerMyPageService {
 
         // (1) User & Worker 조회
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("사용자 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("사용자 정보를 찾을 수 없습니다."));
 
         Worker worker = user.getWorker();
         if (worker == null) {
-            throw new RuntimeException("근로자 정보가 존재하지 않습니다.");
+            throw new NotFoundException("근로자 정보가 존재하지 않습니다.");
         }
 
         // (2) User 정보 수정 (전화번호)
@@ -99,16 +100,16 @@ public class WorkerMyPageService {
 
         // 1. 사용자 및 근로자 정보 조회
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RuntimeException("사용자 정보를 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("사용자 정보를 찾을 수 없습니다."));
         Worker worker = user.getWorker();
 
         if (worker == null) {
-            throw new RuntimeException("근로자 정보가 존재하지 않습니다.");
+            throw new NotFoundException("근로자 정보가 존재하지 않습니다.");
         }
 
         // 2. 파일 정보 조회
         File file = fileRepository.findById(fileId)
-                .orElseThrow(() -> new RuntimeException("파일을 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundException("파일을 찾을 수 없습니다."));
 
         // 3. [핵심] 내 파일이 맞는지 검증
         validateMyFileAccess(file, worker);


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #155

## 📝작업 내용

`RuntimeException` 22곳이 전용 핸들러 없이 `Exception` 핸들러로 떨어져 **모두 500으로 응답**되고 있었고, `ex.getMessage()`가 그대로 클라이언트에 전달되어 내부 정보가 노출되고 있었습니다.
이미 구현되어 있으나 사용되지 않던 커스텀 예외로 교체하고, 핸들러에서 예상하지 못한 예외의 메시지를 마스킹했습니다.

**의도적으로 던진 14곳을 용도에 맞는 예외로 교체**

| 예외 | 상태 | 대상 |
|---|---|---|
| `UnauthorizedException` | 401 | `AttendanceController`(2), `WorkerMyPageController`(1) |
| `NotFoundException` | 404 | `WorkerMyPageService`(7), `AdminWorkerController`(1) |
| `BadRequestException` | 400 | `ContractOcrService`(1), `IdCardOcrService`(2) |

**내부 정보 노출 차단**

- `GlobalExceptionHandler`의 `Exception` 핸들러가 `ex.getMessage()`를 반환하던 것을 고정 문구로 교체하고, 스택트레이스를 서버 로그에 남기도록 변경했습니다. 기존에는 `NullPointerException`의 내부 클래스·필드명, DB 제약 위반 시 테이블명·컬럼명·타 사용자 전화번호가 응답에 포함될 수 있었고 서버에는 아무 기록도 남지 않았습니다
- `SmsService`가 외부 SMS API 응답 본문을 예외 메시지에 담고 있던 부분을 `log.error`로 옮기고 고정 문구로 교체했습니다

**유지한 부분**

외부 API·내부 오류 8곳(`SmsService` 2, `ClovaOcrClient` 4, `IdCardOcrService` 1, `FileService` 1)은 `RuntimeException`을 유지했습니다. 사용자에게 노출할 필요가 없어 500 + 고정 메시지가 적절합니다.

## 💬리뷰 요구사항(선택)

상태 코드가 500에서 401/404/400으로 바뀌지만 웹·앱 모두 응답의 `message` 필드만 읽고 상태 코드로 분기하지 않아 프론트엔드 수정은 불필요합니다.
401로 바뀌는 3곳은 전부 `/api/worker/**`(모바일 앱) 경로라 웹 axios 인터셉터의 401 자동 로그아웃과 무관합니다.

런타임 검증(근로자 앱·관리자 웹·OCR 실패 케이스)은 컨테이너 기동이 필요해 #156 작업 시 함께 진행할 예정입니다.
