### PR TITLE
[REFACTOR] 분산된 타임존 설정 통합 #156

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     restart: always #죽었을때나 재부팅할때 자동으로 재시작 (일부로 멈추는건 재시작 안함)
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      #JVM 기본 타임존. 엔티티가 LocalDateTime 계열이라 저장되는 시각은 이 값만으로 결정됨
+      #JVM이 뜨기 전에 적용되므로 애플리케이션 코드에서 따로 설정할 필요 없음
       - TZ=Asia/Seoul
     env_file:
       - .env
@@ -25,6 +27,8 @@ services:
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
+      #NOW()/CURRENT_TIMESTAMP의 기준. 명시적 오프셋이라
+      #JDBC url에 타임존 파라미터(serverTimezone)를 붙이지 않아도 됨
       - --default-time-zone=+09:00
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p$$MYSQL_ROOT_PASSWORD"]

--- a/src/main/java/com/example/the_labot_backend/TheLabotBackendApplication.java
+++ b/src/main/java/com/example/the_labot_backend/TheLabotBackendApplication.java
@@ -1,22 +1,13 @@
 package com.example.the_labot_backend;
 
-import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-
-import java.util.TimeZone;
 
 @SpringBootApplication
 public class TheLabotBackendApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(TheLabotBackendApplication.class, args);
-	}
-	@PostConstruct
-	public void init() {
-		// 애플리케이션 전역에서 TimeZone을 한국 시간으로 설정
-		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-		System.out.println("현재 시간대: " + TimeZone.getDefault().getID());
 	}
 
 }

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://db:3306/the_labot?serverTimezone=Asia/Seoul
+    url: jdbc:mysql://db:3306/the_labot
     username: root
     password: ${MYSQL_ROOT_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #156

## 📝작업 내용

타임존 설정이 4곳에 분산되어 있었으나, 실제로 저장값을 결정하는 것은 컨테이너 `TZ` 환경변수 하나였습니다.
중복·무효 설정을 제거하고 역할이 다른 2곳만 남겼습니다.

| 위치 | 설정 | 처리 |
|---|---|---|
| `docker-compose.yml` backend | `TZ=Asia/Seoul` | 유지 — JVM 기본 타임존 결정 |
| `TheLabotBackendApplication` | `TimeZone.setDefault(...)` | **제거** — 위와 중복 |
| `application-prod.yaml` | `?serverTimezone=Asia/Seoul` | **제거** — 무효 |
| `docker-compose.yml` db | `--default-time-zone=+09:00` | 유지 — 역할이 다름 |

**제거 근거**

- 엔티티의 시각 필드가 전부 `LocalDateTime`/`LocalDate`/`LocalTime`이라 Connector/J가 타임존 변환을 하지 않습니다. 저장값을 결정하는 유일한 변수는 JVM 기본 타임존이고, 이는 `TZ` 환경변수가 결정합니다
- `@PostConstruct`는 빈 초기화 시점에 실행되어 기동 로그나 먼저 초기화된 빈에는 적용되지 않습니다. 적용 시점이 불명확해 신뢰할 수 없는 방식입니다
- `serverTimezone`은 Connector/J 8.0.23부터 `connectionTimeZone`으로 대체된 deprecated 별칭입니다

**유지 근거**

`--default-time-zone=+09:00`은 MySQL이 드라이버에 보고하는 타임존을 명시적 오프셋으로 고정합니다. `SYSTEM`이면 `KST` 같은 약어를 반환해 `The server time zone value 'KST' is unrecognized` 에러가 날 수 있는데, 이 설정이 그걸 막습니다. **`serverTimezone` 파라미터를 제거할 수 있었던 근거이므로 함께 지우면 안 됩니다.** 주석으로 명시해뒀습니다.

**검증 (Docker 실측)**

| 항목 | 결과 |
|---|---|
| JVM 기본 타임존 | `Asia/Seoul` — `@PostConstruct` 없이 |
| `LocalDateTime.now()` | 실제 시각과 일치 |
| 컨테이너 OS `date` | KST |
| MySQL `NOW()` | KST (`@@global.time_zone = +09:00`) |
| `serverTimezone` 없이 DB 접속 | 정상 기동 |

**부수 효과**

제거된 블록에 `System.out.println`이 있어, 이로써 `System.out.println`이 프로젝트 전체에서 0건이 되었습니다 (#154에서 이 이슈로 넘긴 마지막 1건).

## 💬리뷰 요구사항(선택)

컨테이너 밖(IDE·CI)에서 실행하면 호스트 타임존을 따릅니다. 현재는 문제없으나, 향후 시각 관련 테스트를 추가하면 UTC인 CI 러너에서 어긋날 수 있어 그때 `test { systemProperty 'user.timezone', 'Asia/Seoul' }` 추가가 필요합니다.
