### PR TITLE
[REFACTOR] 파일 targetType enum 전환 및 조회 쿼리 중복 제거 #157

### DIFF
--- a/src/main/java/com/example/the_labot_backend/educations/service/EducationService.java
+++ b/src/main/java/com/example/the_labot_backend/educations/service/EducationService.java
@@ -1,5 +1,6 @@
 package com.example.the_labot_backend.educations.service;
 
+import com.example.the_labot_backend.files.entity.FileTargetType;
 import com.example.the_labot_backend.authuser.entity.User;
 import com.example.the_labot_backend.authuser.repository.UserRepository;
 import com.example.the_labot_backend.educations.dto.EducationCreateRequest;
@@ -91,9 +92,9 @@ public class EducationService {
         }
 
         // --- 4. 파일 업로드 (교육자료 / 사진 / 서명PDF) ---
-        fileService.saveFiles(materials, "EDUCATION-MATERIAL", education.getId());
-        fileService.saveFiles(photos, "EDUCATION-PHOTO", education.getId());
-        fileService.saveFiles(signatures, "EDUCATION-SIGNATURE", education.getId());
+        fileService.saveFiles(materials, FileTargetType.EDUCATION_MATERIAL, education.getId());
+        fileService.saveFiles(photos, FileTargetType.EDUCATION_PHOTO, education.getId());
+        fileService.saveFiles(signatures, FileTargetType.EDUCATION_SIGNATURE, education.getId());
 
     }
 
@@ -132,13 +133,13 @@ public class EducationService {
 
         // 파일 조회
         List<File> materialFiles =
-                fileService.getFilesByTarget("EDUCATION-MATERIAL", edu.getId());
+                fileService.getFilesByTarget(FileTargetType.EDUCATION_MATERIAL, edu.getId());
 
         List<File> photoFiles =
-                fileService.getFilesByTarget("EDUCATION-PHOTO", edu.getId());
+                fileService.getFilesByTarget(FileTargetType.EDUCATION_PHOTO, edu.getId());
 
         List<File> signatureFiles =
-                fileService.getFilesByTarget("EDUCATION-SIGNATURE", edu.getId());
+                fileService.getFilesByTarget(FileTargetType.EDUCATION_SIGNATURE, edu.getId());
 
         return EducationDetailResponse.from(edu,participants,materialFiles,photoFiles,signatureFiles);
     }
@@ -199,14 +200,14 @@ public class EducationService {
         }
 
         // 기존 파일 삭제
-        fileService.deleteFilesByTarget("EDUCATION-MATERIAL", education.getId());
-        fileService.deleteFilesByTarget("EDUCATION-PHOTO", education.getId());
-        fileService.deleteFilesByTarget("EDUCATION-SIGNATURE", education.getId());
+        fileService.deleteFilesByTarget(FileTargetType.EDUCATION_MATERIAL, education.getId());
+        fileService.deleteFilesByTarget(FileTargetType.EDUCATION_PHOTO, education.getId());
+        fileService.deleteFilesByTarget(FileTargetType.EDUCATION_SIGNATURE, education.getId());
 
         // 새 파일 저장
-        fileService.saveFiles(materials, "EDUCATION-MATERIAL", education.getId());
-        fileService.saveFiles(photos, "EDUCATION-PHOTO", education.getId());
-        fileService.saveFiles(signatures, "EDUCATION-SIGNATURE", education.getId());
+        fileService.saveFiles(materials, FileTargetType.EDUCATION_MATERIAL, education.getId());
+        fileService.saveFiles(photos, FileTargetType.EDUCATION_PHOTO, education.getId());
+        fileService.saveFiles(signatures, FileTargetType.EDUCATION_SIGNATURE, education.getId());
     }
 
     @Transactional
@@ -228,9 +229,9 @@ public class EducationService {
         participantRepository.deleteAllByEducation(education);
 
         // 4. 관련 파일 삭제
-        fileService.deleteFilesByTarget("EDUCATION-MATERIAL", education.getId());
-        fileService.deleteFilesByTarget("EDUCATION-PHOTO", education.getId());
-        fileService.deleteFilesByTarget("EDUCATION-SIGNATURE", education.getId());
+        fileService.deleteFilesByTarget(FileTargetType.EDUCATION_MATERIAL, education.getId());
+        fileService.deleteFilesByTarget(FileTargetType.EDUCATION_PHOTO, education.getId());
+        fileService.deleteFilesByTarget(FileTargetType.EDUCATION_SIGNATURE, education.getId());
 
         // 5. 메인 교육일지 삭제
         educationRepository.delete(education);

--- a/src/main/java/com/example/the_labot_backend/files/controller/FileController.java
+++ b/src/main/java/com/example/the_labot_backend/files/controller/FileController.java
@@ -5,6 +5,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.example.the_labot_backend.authuser.entity.User;
 import com.example.the_labot_backend.authuser.repository.UserRepository;
 import com.example.the_labot_backend.files.entity.File;
+import com.example.the_labot_backend.files.entity.FileTargetType;
 import com.example.the_labot_backend.files.repository.FileRepository;
 import com.example.the_labot_backend.workers.entity.Worker;
 import com.example.the_labot_backend.workers.repository.WorkerRepository;
@@ -38,7 +39,7 @@ public class FileController {
     @PostMapping(value = "/save", consumes = {"multipart/form-data"})
     public ResponseEntity<?> uploadFiles(
             @RequestParam("files") List<MultipartFile> files,
-            @RequestParam("targetType") String targetType,
+            @RequestParam("targetType") FileTargetType targetType,
             @RequestParam("targetId") Long targetId
     ) {
 

--- a/src/main/java/com/example/the_labot_backend/files/entity/File.java
+++ b/src/main/java/com/example/the_labot_backend/files/entity/File.java
@@ -31,7 +31,10 @@ public class File {
     private Long size;           // 파일 크기 (byte)
 
     // 어떤 도메인에 속하는 파일인지 구분용
-    private String targetType; // 예: "NOTICE", "WORKER", "EDUCATION", "HAZARD"
-    private Long targetId;     // 예: 1L (공지사항 id)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private FileTargetType targetType;
+
+    private Long targetId;     // targetType이 가리키는 도메인의 id (예: 공지사항 id)
 
 }

--- a/src/main/java/com/example/the_labot_backend/files/entity/FileTargetType.java
+++ b/src/main/java/com/example/the_labot_backend/files/entity/FileTargetType.java
@@ -1,0 +1,27 @@
+package com.example.the_labot_backend.files.entity;
+
+/**
+ * 파일이 어떤 도메인에 속하는지 구분하는 분류값.
+ * 모든 파일이 file 테이블 하나에 저장되므로 (targetType, targetId) 조합으로 소유자를 찾는다.
+ * DB에는 상수명이 그대로 저장된다. (@Enumerated(EnumType.STRING))
+ */
+public enum FileTargetType {
+
+    NOTICE,                 // 공지사항 첨부
+    HAZARD,                 // 위험요소 신고 사진
+    REPORT,                 // 작업일보 첨부
+    SITE_MAP,               // 현장 지도
+
+    EDUCATION_MATERIAL,     // 안전교육 자료
+    EDUCATION_PHOTO,        // 안전교육 사진
+    EDUCATION_SIGNATURE,    // 안전교육 서명
+
+    WORKER_CONTRACT,        // 근로계약서
+    WORKER_LICENSE,         // 자격증
+    WORKER_PAYROLL;         // 급여명세서
+
+    /** 근로자 개인 문서 여부. 문자열 접두사 비교(startsWith("WORKER")) 대체용 */
+    public boolean isWorkerDocument() {
+        return name().startsWith("WORKER_");
+    }
+}

--- a/src/main/java/com/example/the_labot_backend/files/repository/FileRepository.java
+++ b/src/main/java/com/example/the_labot_backend/files/repository/FileRepository.java
@@ -1,10 +1,11 @@
 package com.example.the_labot_backend.files.repository;
 
 import com.example.the_labot_backend.files.entity.File;
+import com.example.the_labot_backend.files.entity.FileTargetType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface FileRepository extends JpaRepository<File, Long> {
-    List<File> findByTargetTypeAndTargetId(String targetType, Long targetId);
+    List<File> findByTargetTypeAndTargetId(FileTargetType targetType, Long targetId);
 }

--- a/src/main/java/com/example/the_labot_backend/files/service/FileService.java
+++ b/src/main/java/com/example/the_labot_backend/files/service/FileService.java
@@ -2,6 +2,7 @@ package com.example.the_labot_backend.files.service;
 
 import com.example.the_labot_backend.files.dto.FileResponse;
 import com.example.the_labot_backend.files.entity.File;
+import com.example.the_labot_backend.files.entity.FileTargetType;
 import com.example.the_labot_backend.files.repository.FileRepository;
 import io.awspring.cloud.s3.ObjectMetadata;
 import io.awspring.cloud.s3.S3Resource;
@@ -35,7 +36,7 @@ public class FileService {
 
     //파일저장
     @Transactional
-    public void saveFiles(List<MultipartFile> multipartFiles, String targetType, Long targetId) {
+    public void saveFiles(List<MultipartFile> multipartFiles, FileTargetType targetType, Long targetId) {
 
         //파일이 없으면 종료
         if (multipartFiles == null || multipartFiles.isEmpty()) {
@@ -55,7 +56,7 @@ public class FileService {
             //targetType이 "SITE"이면 site/ 라는 문자열 만듦
             //s3는 폴더명/ 붙이면 자동으로 폴더 안에 저장해줌
             //s3는 사실 폴더라는 개념이 없음 우리한테는 그렇게 보여질뿐 걍 경로임
-            String folderPath = targetType.toLowerCase() + "/";
+            String folderPath = targetType.name().toLowerCase() + "/";
 
             //s3에 저장될 최종 이름
             String storedName = folderPath + uuid + "_" + originalName;
@@ -102,7 +103,7 @@ public class FileService {
 
     //파일삭제
     @Transactional
-    public void deleteFilesByTarget(String targetType, Long targetId) {
+    public void deleteFilesByTarget(FileTargetType targetType, Long targetId) {
         //db에서 파일 찾기
         List<File> files = fileRepository.findByTargetTypeAndTargetId(targetType, targetId);
 
@@ -117,14 +118,13 @@ public class FileService {
 
     //조회하는건 수정없음. url 반환만 해주면 됨
     @Transactional(readOnly = true)
-    public List<File> getFilesByTarget(String targetType, Long targetId) {
+    public List<File> getFilesByTarget(FileTargetType targetType, Long targetId) {
         return fileRepository.findByTargetTypeAndTargetId(targetType, targetId);
     }
 
-    //얘는 위에 조회랑 다른게 뭐지?
+    //위와 같은 조회이며 응답 DTO로 변환해서 반환한다. 쿼리는 위 메서드에 위임
     @Transactional(readOnly = true)
-    public List<FileResponse> getFilesResponseByTarget(String targetType, Long targetId) {
-        List<File> files = fileRepository.findByTargetTypeAndTargetId(targetType, targetId);
-        return FileResponse.fromList(files);
+    public List<FileResponse> getFilesResponseByTarget(FileTargetType targetType, Long targetId) {
+        return FileResponse.fromList(getFilesByTarget(targetType, targetId));
     }
 }

--- a/src/main/java/com/example/the_labot_backend/hazards/service/HazardService.java
+++ b/src/main/java/com/example/the_labot_backend/hazards/service/HazardService.java
@@ -1,5 +1,6 @@
 package com.example.the_labot_backend.hazards.service;
 
+import com.example.the_labot_backend.files.entity.FileTargetType;
 import com.example.the_labot_backend.authuser.entity.User;
 import com.example.the_labot_backend.authuser.repository.UserRepository;
 import com.example.the_labot_backend.files.entity.File;
@@ -51,7 +52,7 @@ public class HazardService {
 
         hazardRepository.save(hazard);
 
-        fileService.saveFiles(files, "HAZARD", hazard.getId());
+        fileService.saveFiles(files, FileTargetType.HAZARD, hazard.getId());
     }
 
     // userId를 통한 위험요소 신고 목록 조회
@@ -88,7 +89,7 @@ public class HazardService {
                 .orElseThrow(() -> new NotFoundException("해당 위험요소 신고를 찾을 수 없습니다.(getHazardDetail) hazardId:" + hazardId));
 
         // 파일 조회
-        List<File> files = fileService.getFilesByTarget("HAZARD", hazardId);
+        List<File> files = fileService.getFilesByTarget(FileTargetType.HAZARD, hazardId);
 
         return new HazardDetailResponse(hazard,files);
     }
@@ -122,7 +123,7 @@ public class HazardService {
                 .orElseThrow(()-> new NotFoundException("해당 위험요소 신고를 찾을 수 없습니다.(deleteHazard) hazardId:" + hazardId));
 
         // 위험요소 신고에 연결된 파일 삭제
-        fileService.deleteFilesByTarget("HAZARD", hazardId);
+        fileService.deleteFilesByTarget(FileTargetType.HAZARD, hazardId);
 
         // 위험요소 신고 삭제
         hazardRepository.deleteById(hazardId);

--- a/src/main/java/com/example/the_labot_backend/map/controller/AdminMapController.java
+++ b/src/main/java/com/example/the_labot_backend/map/controller/AdminMapController.java
@@ -1,5 +1,6 @@
 package com.example.the_labot_backend.map.controller;
 
+import com.example.the_labot_backend.files.entity.FileTargetType;
 import com.example.the_labot_backend.files.dto.FileResponse;
 import com.example.the_labot_backend.files.service.FileService;
 import com.example.the_labot_backend.map.service.MapService;
@@ -25,7 +26,7 @@ public class AdminMapController {
     @GetMapping("/{siteId}/map")
     public ResponseEntity<?> getSiteMap(@PathVariable Long siteId) {
 
-        List<FileResponse> response = mapService.getMapBySite("SITE_MAP", siteId);
+        List<FileResponse> response = mapService.getMapBySite(FileTargetType.SITE_MAP, siteId);
 
         return ResponseEntity.ok(Map.of(
                 "status", 200,

--- a/src/main/java/com/example/the_labot_backend/map/service/MapService.java
+++ b/src/main/java/com/example/the_labot_backend/map/service/MapService.java
@@ -1,5 +1,6 @@
 package com.example.the_labot_backend.map.service;
 
+import com.example.the_labot_backend.files.entity.FileTargetType;
 import com.example.the_labot_backend.authuser.entity.User;
 import com.example.the_labot_backend.authuser.repository.UserRepository;
 import com.example.the_labot_backend.files.dto.FileResponse;
@@ -30,10 +31,10 @@ public class MapService {
         Long siteId = user.getSite().getId();
 
         // 파일 삭제
-        fileService.deleteFilesByTarget("SITE_MAP", siteId);
+        fileService.deleteFilesByTarget(FileTargetType.SITE_MAP, siteId);
         
         // 파일 저장
-        fileService.saveFiles(files, "SITE_MAP", siteId);
+        fileService.saveFiles(files, FileTargetType.SITE_MAP, siteId);
     }
 
     // 본인 현장 지도 조회
@@ -47,12 +48,12 @@ public class MapService {
         Long siteId = user.getSite().getId();
 
         // 파일 추출 (지도)
-        return fileService.getFilesResponseByTarget("SITE_MAP", siteId);
+        return fileService.getFilesResponseByTarget(FileTargetType.SITE_MAP, siteId);
     }
 
     // 특정 현장 지도 조회
     @Transactional(readOnly = true)
-    public List<FileResponse> getMapBySite(String targetType, Long siteId){
+    public List<FileResponse> getMapBySite(FileTargetType targetType, Long siteId){
         // 파일 추출 (지도)
         return fileService.getFilesResponseByTarget(targetType, siteId);
     }
@@ -67,7 +68,7 @@ public class MapService {
         // user로 siteId 찾기
         Long siteId = user.getSite().getId();
 
-        fileService.deleteFilesByTarget("SITE_MAP", siteId);
+        fileService.deleteFilesByTarget(FileTargetType.SITE_MAP, siteId);
     }
 
 }

--- a/src/main/java/com/example/the_labot_backend/notices/service/NoticeService.java
+++ b/src/main/java/com/example/the_labot_backend/notices/service/NoticeService.java
@@ -1,5 +1,6 @@
 package com.example.the_labot_backend.notices.service;
 
+import com.example.the_labot_backend.files.entity.FileTargetType;
 import com.example.the_labot_backend.authuser.entity.User;
 import com.example.the_labot_backend.authuser.repository.UserRepository;
 import com.example.the_labot_backend.files.entity.File;
@@ -66,7 +67,7 @@ public class NoticeService {
         );
 
         // 파일 업로드 (로컬 or S3)
-        fileService.saveFiles(files, "NOTICE", notice.getId());
+        fileService.saveFiles(files, FileTargetType.NOTICE, notice.getId());
     }
 
     // userId를 통해 현장별 공지사항 목록 조회
@@ -117,7 +118,7 @@ public class NoticeService {
             throw new ForbiddenException("해당 공지사항에 접근 권한이 없습니다.");
         }
 
-        List<File> files = fileService.getFilesByTarget("NOTICE", noticeId);
+        List<File> files = fileService.getFilesByTarget(FileTargetType.NOTICE, noticeId);
 
         return new NoticeDetailResponse(notice, files);
     }
@@ -158,15 +159,15 @@ public class NoticeService {
         notice.setPinned(form.isPinned());
 
         // 기존 파일 전체 삭제
-        fileService.deleteFilesByTarget("NOTICE", noticeId);
+        fileService.deleteFilesByTarget(FileTargetType.NOTICE, noticeId);
 
         // 새 파일 업로드
         if (newFiles != null && !newFiles.isEmpty()) {
-            fileService.saveFiles(newFiles, "NOTICE", notice.getId());
+            fileService.saveFiles(newFiles, FileTargetType.NOTICE, notice.getId());
         }
 
         // 최신 파일 목록 조회
-        List<File> files = fileService.getFilesByTarget("NOTICE", noticeId);
+        List<File> files = fileService.getFilesByTarget(FileTargetType.NOTICE, noticeId);
 
         // 최신 공지사항 정보 + 파일 함께 반환
         return new NoticeDetailResponse(notice, files);
@@ -187,7 +188,7 @@ public class NoticeService {
         }
 
         // 공지사항에 연결된 파일 모두 삭제
-        fileService.deleteFilesByTarget("NOTICE", noticeId);
+        fileService.deleteFilesByTarget(FileTargetType.NOTICE, noticeId);
 
         // 공지사항 삭제
         noticeRepository.delete(notice);

--- a/src/main/java/com/example/the_labot_backend/notices/worker/service/WorkerNoticeService.java
+++ b/src/main/java/com/example/the_labot_backend/notices/worker/service/WorkerNoticeService.java
@@ -1,5 +1,6 @@
 package com.example.the_labot_backend.notices.worker.service;
 
+import com.example.the_labot_backend.files.entity.FileTargetType;
 import com.example.the_labot_backend.authuser.entity.User;
 import com.example.the_labot_backend.files.dto.FileResponse;
 import com.example.the_labot_backend.files.entity.File;
@@ -93,7 +94,7 @@ public class WorkerNoticeService {
 
         // 2. [★ 수정됨] 파일 DTO 목록 바로 조회 (엔티티 조회 X)
         // FileService의 getFilesResponseByTarget 메서드를 사용하여 바로 DTO 리스트를 받습니다.
-        List<FileResponse> fileResponses = fileService.getFilesResponseByTarget("NOTICE", noticeId);
+        List<FileResponse> fileResponses = fileService.getFilesResponseByTarget(FileTargetType.NOTICE, noticeId);
 
         // 3. 조립해서 반환
         return WorkerNoticeDetailDto.of(notice, fileResponses);

--- a/src/main/java/com/example/the_labot_backend/reports/service/ReportService.java
+++ b/src/main/java/com/example/the_labot_backend/reports/service/ReportService.java
@@ -1,5 +1,6 @@
 package com.example.the_labot_backend.reports.service;
 
+import com.example.the_labot_backend.files.entity.FileTargetType;
 import com.example.the_labot_backend.authuser.entity.User;
 import com.example.the_labot_backend.authuser.repository.UserRepository;
 import com.example.the_labot_backend.files.dto.FileResponse;
@@ -131,7 +132,7 @@ public class ReportService {
         List<ReportMaterial> materialList = reportMaterialRepository.findByReportId(reportId);
 
         // 파일 조회 (targetType = REPORT)
-        List<FileResponse> fileResponses = fileService.getFilesResponseByTarget("REPORT", reportId);
+        List<FileResponse> fileResponses = fileService.getFilesResponseByTarget(FileTargetType.REPORT, reportId);
 
         // 5) DTO로 변환하여 반환
         return ReportDetailResponse.builder()
@@ -246,7 +247,7 @@ public class ReportService {
         }
 
         // 관련 파일 삭제
-        fileService.deleteFilesByTarget("REPORT",reportId);
+        fileService.deleteFilesByTarget(FileTargetType.REPORT,reportId);
 
         return reportId;
     }
@@ -271,7 +272,7 @@ public class ReportService {
         reportRepository.deleteById(reportId);
 
         // 관련 파일 삭제
-        fileService.deleteFilesByTarget("REPORT",reportId);
+        fileService.deleteFilesByTarget(FileTargetType.REPORT,reportId);
 
     }
 

--- a/src/main/java/com/example/the_labot_backend/workers/service/WorkerMyPageService.java
+++ b/src/main/java/com/example/the_labot_backend/workers/service/WorkerMyPageService.java
@@ -1,5 +1,6 @@
 package com.example.the_labot_backend.workers.service;
 
+import com.example.the_labot_backend.files.entity.FileTargetType;
 import com.example.the_labot_backend.authuser.entity.User;
 import com.example.the_labot_backend.authuser.repository.UserRepository;
 import com.example.the_labot_backend.files.dto.FileResponse;
@@ -48,14 +49,14 @@ public class WorkerMyPageService {
 
         // [★ 수정됨] FileService를 통해 S3 URL이 포함된 DTO 리스트 조회
         // 1) 근로계약서 (WORKER_CONTRACT) - 1개만 가져옴
-        List<FileResponse> contracts = fileService.getFilesResponseByTarget("WORKER_CONTRACT", worker.getId());
+        List<FileResponse> contracts = fileService.getFilesResponseByTarget(FileTargetType.WORKER_CONTRACT, worker.getId());
         FileResponse contractFile = contracts.isEmpty() ? null : contracts.get(0);
 
         // 2) 급여명세서 (WORKER_PAYROLL) - 전체 리스트
-        List<FileResponse> payrolls = fileService.getFilesResponseByTarget("WORKER_PAYROLL", worker.getId());
+        List<FileResponse> payrolls = fileService.getFilesResponseByTarget(FileTargetType.WORKER_PAYROLL, worker.getId());
 
         // 3) 자격증 (WORKER_LICENSE) - 전체 리스트
-        List<FileResponse> licenses = fileService.getFilesResponseByTarget("WORKER_LICENSE", worker.getId());
+        List<FileResponse> licenses = fileService.getFilesResponseByTarget(FileTargetType.WORKER_LICENSE, worker.getId());
 
         // DTO 변환 후 반환
         return WorkerMyPageResponse.from(user, worker, contractFile, payrolls, licenses);
@@ -122,8 +123,8 @@ public class WorkerMyPageService {
      * [검증 로직] 요청한 파일이 내 것이 맞는지 확인
      */
     private void validateMyFileAccess(File file, Worker worker) {
-        // 1. 파일의 타겟이 'WORKER'로 시작하는지 확인
-        if (file.getTargetType() == null || !file.getTargetType().startsWith("WORKER")) {
+        // 1. 근로자 개인 문서인지 확인
+        if (file.getTargetType() == null || !file.getTargetType().isWorkerDocument()) {
             throw new SecurityException("접근할 수 없는 파일 유형입니다.");
         }
 

--- a/src/main/java/com/example/the_labot_backend/workers/service/WorkerService.java
+++ b/src/main/java/com/example/the_labot_backend/workers/service/WorkerService.java
@@ -1,5 +1,6 @@
 package com.example.the_labot_backend.workers.service;
 
+import com.example.the_labot_backend.files.entity.FileTargetType;
 import com.example.the_labot_backend.attendance.dto.AttendanceUpdateRequestDto;
 import com.example.the_labot_backend.attendance.entity.Attendance;
 import com.example.the_labot_backend.attendance.repository.AttendanceRepository;
@@ -124,7 +125,7 @@ public class WorkerService {
 
         workerRepository.save(worker);
         if (contractFiles != null && !contractFiles.isEmpty()) {
-            fileService.saveFiles(contractFiles, "WORKER_CONTRACT", worker.getId());
+            fileService.saveFiles(contractFiles, FileTargetType.WORKER_CONTRACT, worker.getId());
         }
     }
     // --- 헬퍼 메서드 ---
@@ -225,15 +226,15 @@ public class WorkerService {
         Worker worker = workerRepository.findById(workerId)
                 .orElseThrow(() -> new NotFoundException("해당 근로자를 찾을 수 없습니다."));
 
-        // 1. 근로계약서 (우리가 저장할 때 targetType="WORKER_CONTRACT"로 하기로 약속)
-        List<FileResponse> contractList = fileService.getFilesResponseByTarget("WORKER_CONTRACT", workerId);
+        // 1. 근로계약서
+        List<FileResponse> contractList = fileService.getFilesResponseByTarget(FileTargetType.WORKER_CONTRACT, workerId);
         FileResponse contractFile = contractList.isEmpty() ? null : contractList.get(0); // 1개만 꺼냄
 
-        // 2. 임금명세서 (targetType="WORKER_PAYSTUB" - 나중에 급여대장 만들 때 이 타입으로 저장하면 됨)
-        List<FileResponse> payStubs = fileService.getFilesResponseByTarget("WORKER_PAYSTUB", workerId);
+        // 2. 임금명세서 (저장 로직 미구현 상태라 현재는 항상 빈 리스트)
+        List<FileResponse> payStubs = fileService.getFilesResponseByTarget(FileTargetType.WORKER_PAYROLL, workerId);
 
-        // 3. 자격증 (targetType="WORKER_LICENSE" - 자격증 올릴 때 이 타입으로 저장)
-        List<FileResponse> licenses = fileService.getFilesResponseByTarget("WORKER_LICENSE", workerId);
+        // 3. 자격증
+        List<FileResponse> licenses = fileService.getFilesResponseByTarget(FileTargetType.WORKER_LICENSE, workerId);
 
         // 2. [추가] 출퇴근 기록(List<Attendance>) -> DTO 리스트로 변환
         List<WorkerDetailResponse.AttendanceLogDto> attendanceLogs = worker.getAttendanceRecords().stream()
@@ -324,8 +325,8 @@ public class WorkerService {
             throw new IllegalStateException("관리자에게 배정된 현장이 없습니다.");
         }
 
-        // 파일이 'WORKER' 관련 파일인지 확인 (안전장치)
-        if (file.getTargetType() != null && file.getTargetType().startsWith("WORKER")) {
+        // 근로자 개인 문서인지 확인 (안전장치)
+        if (file.getTargetType() != null && file.getTargetType().isWorkerDocument()) {
             Long workerId = file.getTargetId();
 
             // 파일 주인(근로자) 조회


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #157

## 📝작업 내용

파일 `targetType`이 문자열 리터럴로 흩어져 있어 컴파일러가 검증할 수 없었고, 그 결과 **관리자 화면과 근로자 마이페이지가 서로 다른 키로 급여명세서를 조회하는 버그**가 있었습니다.

```java
// WorkerService:233        관리자 화면
getFilesResponseByTarget("WORKER_PAYSTUB", workerId);

// WorkerMyPageService:54   근로자 마이페이지
getFilesResponseByTarget("WORKER_PAYROLL", worker.getId());
```

모든 파일이 `file` 테이블 하나에 저장되고 `(targetType, targetId)`로 소유자를 찾는 구조라, DB에 외래키를 걸 수 없어 무결성을 애플리케이션이 책임져야 합니다. 이 값이 틀리면 저장된 파일을 조회로 찾을 수 없고 코드 수정만으로는 복구되지 않습니다.

**주요 변경**

| 대상 | 내용 |
|---|---|
| `FileTargetType` (신규) | enum 10종 + `isWorkerDocument()` |
| `File` 엔티티 | `targetType`을 `String` → enum (`@Enumerated(EnumType.STRING)`) |
| `FileRepository` · `FileService` · `MapService` · `FileController` | 시그니처를 enum으로 |
| 서비스 9개 | 문자열 리터럴 40곳 → enum 상수 |

**부수 정리**

- `startsWith("WORKER")`로 권한을 판단하던 2곳(`WorkerService`, `WorkerMyPageService`)을 `isWorkerDocument()`로 대체했습니다. 파일 이름 규칙에 권한 로직이 의존하고 있었습니다
- `EDUCATION-PHOTO`(하이픈)와 `WORKER_CONTRACT`(언더스코어)로 갈려 있던 네이밍을 언더스코어로 통일했습니다
- `getFilesResponseByTarget`이 `getFilesByTarget`에 위임하도록 바꿔 동일 쿼리 중복 호출을 제거했습니다

**검증**

시그니처를 바꾸자 컴파일 에러가 88개 발생했고, 전부 해소한 뒤 빌드가 통과했습니다. 컴파일러가 호출부를 한 곳도 빠뜨리지 않고 찾아준 셈입니다.

| 항목 | 결과 |
|---|---|
| 컴파일 에러 | 88 → 0 |
| 문자열 리터럴 잔존 | 40 → 0 |
| 빌드 | 통과 |

## 💬리뷰 요구사항(선택)

**영향 범위 없음을 확인했습니다.**

- **DB 저장값** — 운영 DB가 존재하지 않아 기존 데이터 보존이 불필요합니다. enum 상수명이 그대로 저장값이 되며 값 매핑 필드를 두지 않았습니다
- **API 응답** — `targetType`은 응답 DTO에 포함되지 않습니다. 프론트엔드 전수 조사 결과 `targetType` 사용처가 0곳이며, 이 값을 파라미터로 받는 `POST /files/save`도 호출되지 않습니다
- **`DashboardService`의 `.type("HAZARD")`** — 파일과 무관한 대시보드 활동 유형 라벨이므로 교체 대상에서 제외했습니다. 문자열이 겹쳐 일괄 치환 시 잘못 바뀔 수 있는 지점이었습니다

급여명세서는 키를 `WORKER_PAYROLL`로 통일했으나, 해당 타입으로 파일을 저장하는 코드가 없어 기능 자체는 여전히 동작하지 않습니다. 별도 이슈로 분리가 필요합니다.
