### PR TITLE
[BUILD] Docker 빌드 캐시 레이어 분리 및 런타임 이미지 JRE 전환 #164

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,26 @@
 
 
 # Gradle 공식 이미지 사용하기 위해 멀티스테이지 빌드
-#1단계 빌드먼저
-FROM gradle:8.14.3-jdk21 AS builder
-WORKDIR /app
-COPY . .
-RUN gradle bootJar --no-daemon
-#빌드 속도 최적화를 위해 백그라운드에서 항상 실행되는 프로세스를 사용
-#매번 JVM을 새로 띄우지 않고 데몬 프로세스에 연결해서 빌드 속도 높임
-#Docker 레이어는 캐시와 별개이기 때문에 안하는게 나음 (독립으로 하자)
 
-#2단계 위애 생성된 jar로 실행하기
-FROM eclipse-temurin:21-jdk
+#1단계: 의존성 다운로드
+#build.gradle만 먼저 복사해서 의존성을 별도 레이어로 고정한다.
+#소스(src)가 바뀌어도 이 레이어는 캐시에서 재사용되고,
+#build.gradle이 바뀔 때만 다시 실행된다.
+FROM gradle:8.14.3-jdk21 AS deps
+WORKDIR /app
+COPY build.gradle settings.gradle ./
+RUN gradle dependencies --no-daemon
+#--no-daemon: 컨테이너는 빌드 후 종료되므로 데몬을 띄울 이유가 없음
+
+#2단계: 빌드
+#소스가 바뀌면 여기부터만 재실행된다. 의존성은 1단계 레이어에 이미 있음
+FROM deps AS builder
+COPY src ./src
+RUN gradle bootJar --no-daemon
+
+#3단계: 위에 생성된 jar로 실행하기
+#실행만 하므로 컴파일러가 포함된 jdk 대신 jre 사용 (이미지 크기 절감)
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #164

## 📝작업 내용

CD에 빌드 캐시(#79)를 적용했으나 소스 변경 시 `build-and-push`가 매번 ~120초로, 캐시가 사실상 적중하지 않던 문제를 해결했습니다.

**원인**

`COPY . .`가 `RUN gradle bootJar`보다 앞에 있어, 소스 한 줄만 바뀌어도 의존성 다운로드까지 통째로 재실행됐습니다. 로컬 재현 결과 웜 빌드 52초 중 48.2초가 해당 스텝이었습니다.

**변경**

- `build.gradle`/`settings.gradle`만 먼저 복사하고 `gradle dependencies`를 별도 스테이지(deps)로 분리 — 소스 변경 시 이 레이어는 캐시에서 재사용됩니다
- 소스(`src`)는 이후 스테이지에서 복사, `bootJar`는 컴파일만 수행합니다
- 실행 스테이지를 `eclipse-temurin:21-jdk` → `21-jre`로 교체했습니다. 실행 전용 컨테이너에 컴파일러가 불필요하며, alpine은 musl libc라 네이티브 의존성(AWS SDK·MySQL 커넥터) 검증 비용이 있어 제외했습니다

**측정 (로컬, n=3 중앙값)**

| 지표 | 개선 전 | 개선 후 |
|---|---|---|
| 웜 빌드 (소스 한 줄 변경) | 52초 | **24초 (-54%)** |
| gradle 스텝 | 48.2초 (다운로드+컴파일) | 21.2초 (컴파일만) |
| 이미지 크기 | 939MB | **669MB (-29%)** |
| 콜드 빌드 | 84~96초 | 97초 (동일 — 예상된 결과) |

빌드 로그에서 소스 변경 시에도 의존성 레이어가 `CACHED`로 재사용됨을 확인했습니다:

```
#10 [deps 4/4] RUN gradle dependencies --no-daemon
#10 CACHED
```

**검증**

- JRE 이미지에서 기동 6.7초 정상
- 컨테이너 타임존 KST 유지 (tzdata 포함 확인, #156 설정)
- API 스모크 — 로그인 401(BCrypt·JPA·MySQL 커넥터 정상), 잘못된 JSON 500 + 메시지 마스킹(예외 핸들러 정상)

## 💬리뷰 요구사항(선택)

- `gradle dependencies`가 모든 configuration을 받았는지는 bootJar 스텝 시간으로 검증했습니다. 의존성이 누락됐다면 재다운로드로 40초대가 나왔을 텐데 21.2초(순수 컴파일)입니다
- `build.gradle` 변경 시에는 여전히 전체 재다운로드가 발생하며 이는 의도된 동작입니다
- 머지 후 소스 변경 커밋으로 GitHub Actions 러너에서의 실측(~120초 → ?)을 진행할 예정입니다
- Dockerfile 상단의 주석 처리된 초기 시도는 시행착오 기록으로 보존했습니다
