### PR TITLE
[REFACTOR] 미사용 필드 및 Repository 메서드 정리 #166

### DIFF
--- a/src/main/java/com/example/the_labot_backend/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/com/example/the_labot_backend/attendance/repository/AttendanceRepository.java
@@ -24,9 +24,6 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     List<Long> findWorkerIdsWithObjection(@Param("siteId") Long siteId);
 
 
-    // 1. 오늘 출근한 근로자 수
-    long countByWorker_User_Site_IdAndDate(Long siteId, LocalDate date);
-
     // 리스트: 오늘 날짜(date) + 출근시간 최신순 5개
     List<Attendance> findTop5ByWorker_User_Site_IdAndDateOrderByClockInTimeDesc(Long siteId, LocalDate date);
 }

--- a/src/main/java/com/example/the_labot_backend/attendanceRecord/repository/AttendanceRecordRepository.java
+++ b/src/main/java/com/example/the_labot_backend/attendanceRecord/repository/AttendanceRecordRepository.java
@@ -20,15 +20,6 @@ public interface AttendanceRecordRepository extends JpaRepository<AttendanceReco
        """)
     List<AttendanceRecord> findMonthlyRecords(Long workerId, int year, int month);
 
-    // 해당 siteId와 년/월에 맞는 기록 가져오기 
-    @Query("""
-       SELECT ar FROM AttendanceRecord ar
-       WHERE ar.worker.user.site.id = :siteId
-       AND FUNCTION('YEAR', ar.workDate) = :year
-       AND FUNCTION('MONTH', ar.workDate) = :month
-       """)
-    List<AttendanceRecord> findMonthlyRecordsBySite(Long siteId, int year, int month);
-
     // 특정 날짜 사이 총 공수 가져오기
     @Query("""
         SELECT COALESCE(SUM(a.manHour), 0)

--- a/src/main/java/com/example/the_labot_backend/authuser/repository/UserRepository.java
+++ b/src/main/java/com/example/the_labot_backend/authuser/repository/UserRepository.java
@@ -19,9 +19,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // siteID를 통해 해당 역할의 인원 수 조회
     int countBySite_IdAndRole(Long siteId, Role role);
 
-    // headOfficeId를 통해 해당 역할의 인원 수 조회
-    int countByHeadOffice_IdAndRole(Long headOfficeId, Role role);
-
     List<User> findByHeadOfficeAndSiteAndRole(HeadOffice headOffice, Site site, Role role);
 
 }

--- a/src/main/java/com/example/the_labot_backend/payroll/repository/PayrollRepository.java
+++ b/src/main/java/com/example/the_labot_backend/payroll/repository/PayrollRepository.java
@@ -19,15 +19,6 @@ public interface PayrollRepository extends JpaRepository<Payroll, Long> {
            """)
     List<Payroll> findBySiteAndMonth(Long siteId, int year, int month);
 
-    // 해당 년,월에 만들어진 payroll이 있는지 확인 개수
-    @Query("""
-       SELECT COUNT(p) FROM Payroll p
-       WHERE p.site.id = :siteId
-       AND FUNCTION('YEAR', p.payDate) = :year
-       AND FUNCTION('MONTH', p.payDate) = :month
-       """)
-    Long countBySiteAndYearMonth(Long siteId, int year, int month);
-
     @Query("""
         SELECT p FROM Payroll p
         WHERE p.worker.id = :workerId

--- a/src/main/java/com/example/the_labot_backend/workers/repository/WorkerRepository.java
+++ b/src/main/java/com/example/the_labot_backend/workers/repository/WorkerRepository.java
@@ -9,13 +9,6 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface WorkerRepository extends JpaRepository<Worker, Long> {
-    List<Worker> findAllByStatus(WorkerStatus status);
-
-    @Query("SELECT w FROM Worker w " +
-            "JOIN FETCH w.user u " +
-            "JOIN FETCH u.site s " +
-            "WHERE u.headOffice.id = :headOfficeId")
-    List<Worker> findAllByHeadOfficeId(@Param("headOfficeId") Long headOfficeId);
     List<Worker> findByUser_Site_IdAndStatusNot(Long siteId, WorkerStatus status);
 
 
@@ -27,8 +20,6 @@ public interface WorkerRepository extends JpaRepository<Worker, Long> {
     List<Worker> findWorkersBySiteId(@Param("siteId") Long siteId);
 
     List<Worker> findByIdIn(List<Long> userIds);
-    // [★ 신규 추가] 내 현장의 '퇴직자가 아닌' 근로자 총원 카운트
-    long countByUser_Site_IdAndStatusNot(Long siteId, WorkerStatus status);
     // [★ 핵심] 특정 현장의, 특정 상태(ACTIVE)인 근로자 수 카운트
     long countByUser_Site_IdAndStatus(Long siteId, WorkerStatus status);
 }

--- a/src/main/java/com/example/the_labot_backend/workers/service/WorkerMyPageService.java
+++ b/src/main/java/com/example/the_labot_backend/workers/service/WorkerMyPageService.java
@@ -24,9 +24,7 @@ public class WorkerMyPageService {
     private final UserRepository userRepository;
     private final FileRepository fileRepository; // [★] 개별 조회를 위해 추가
 
-    private final FileService fileService; // [★] 우리가 만든 파일 서비스 사용
-    // 기존 로컬 저장 경로 유지
-    private final String UPLOAD_DIR = System.getProperty("user.dir") + "/uploads/";
+    private final FileService fileService;
 
     // 1. 마이페이지 정보 조회
     @Transactional(readOnly = true)


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #166

## 📝작업 내용

S3 전환 이전의 잔재 필드와 호출되지 않는 Repository 메서드를 제거했습니다.

- `WorkerMyPageService`의 `UPLOAD_DIR` 필드 삭제 — 로컬 파일시스템 저장 시절(#100 이전)의 경로 변수로, 선언 이후 사용처가 없습니다
- 호출 0회 Repository 메서드 7개 삭제 — `AttendanceRepository`(1), `UserRepository`(1), `AttendanceRecordRepository`(1), `WorkerRepository`(3), `PayrollRepository`(1). 삭제 직전 전체 소스 대상으로 호출 0회를 재검증했습니다

## 💬리뷰 요구사항(선택)

- `findMonthlyRecordsBySite`, `findAllByHeadOfficeId`, `countBySiteAndYearMonth`는 직접 작성된 `@Query`지만 호출부가 없어 함께 제거했습니다. 필요해지면 git 이력에서 복구할 수 있습니다
- Spring Data 메서드는 선언만으로 쿼리가 생성되므로 실행 비용은 없으나, 사용되지 않는 선언이 실제 사용 메서드를 가리는 가독성 비용이 있어 정리했습니다
