### PR TITLE
[CI] CD의 GHA 빌드 캐시 제거 #168

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # 캐싱
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -29,9 +28,8 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: rmsckd1640/the-labot-backend:latest
-
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          #GHA 캐시(type=gha)는 사용하지 않는다.
+          #러너의 Maven 다운로드(24.5s)보다 캐시 레이어 전송 비용(다운 ~19s + 업로드 33~56s)이 커서 순손실 (#168)
 
   deploy:
     needs: build-and-push


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #168

## 📝작업 내용

CD의 GHA 빌드 캐시(`cache-from/to: type=gha`)를 제거했습니다.

#164에서 Dockerfile 레이어를 분리한 뒤 캐시 적중 상태의 CD를 실측한 결과, GitHub 러너에서는 캐시가 순손실이었습니다.

| 항목 | 실측 |
|---|---|
| 캐시가 절약하는 것 — Maven 의존성 다운로드 | 24.5초 |
| 캐시 비용 — GHA에서 캐시 레이어 다운로드 | ~19초 |
| 캐시 비용 — GHA로 캐시 레이어 업로드 (mode=max) | 33~56초 |

로컬(느린 회선)에서는 의존성 다운로드가 병목이라 캐시 가치가 크지만, 러너는 Maven Central과의 회선이 빨라 다운로드 자체가 저렴합니다. 반면 수백 MB의 의존성 레이어를 GHA 캐시 저장소와 매 실행 주고받는 전송 비용이 그 절약분을 상회합니다.

실제로 캐시 적중 상태의 `build-and-push`가 113초로, 개선 전(~120초)과 큰 차이가 없었습니다. 되돌아보면 개선 전 120초에도 한 번도 적중하지 못할 캐시를 매 배포마다 업로드하는 비용(~50초)이 포함되어 있었습니다.

같은 이유가 재발하지 않도록 워크플로에 근거 주석을 남겼습니다.

## 💬리뷰 요구사항(선택)

- Dockerfile의 레이어 분리는 유지합니다. 로컬 개발 빌드(-54%)와 이미지 크기(-29%)는 캐시와 무관한 이득입니다
- 머지 후 첫 CD 실행이 "캐시 없는 구성"의 측정값이 됩니다 (예상 85~90초)
